### PR TITLE
Cleanups

### DIFF
--- a/README
+++ b/README
@@ -8,12 +8,12 @@ on the musl-libc mailing-list.
 http://www.openwall.com/lists/musl/2013/12/03/26
 
 After that I implemented musl-test-framework which is no longer
-online available. It was just to test musl. The next incarnation
+available online. It was just to test musl. The next incarnation
 was adk-test-framework, which tries to be more flexible regarding
 what project should be tested (offline). 
 
 Both solutions required binary kernel and initramfs for the Qemu
-runtime tests and toolchains for the compiling.
+runtime tests and toolchains for compiling.
 
 The third incarnation now uses OpenADK to build a toolchain, 
 the base system and the C library.  Then it runs either a 
@@ -21,7 +21,7 @@ libc test suite, the ltp project or a native compile of a toolchain.
 More tests can be implemented later.
 
 A full build without any options needs 320 GB of disk space.
-All combinations of C library and architectures are build.
+All combinations of C library and architectures are built.
 
 Have fun
  Waldemar

--- a/embedded-test.sh
+++ b/embedded-test.sh
@@ -1690,16 +1690,20 @@ for lib in ${libc}; do
       echo "Not a directory."
       exit 1
     fi
-    usrc=$(mktemp -d /tmp/XXXX)
-    echo "Creating C library source tarball openadk/dl/${libver}.tar.xz"
-    cp -a $libcsource $usrc/$libver
-    mkdir -p $topdir/openadk/dl 2>/dev/null
-    rm $topdir/openadk/dl/${libver}.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/${libver}.tar.xz ${libver} && rm -rf $usrc)
-    touch $topdir/openadk/dl/${libver}.tar.xz.nohash
-    # we need to clean system, when external source is used
-    if [ $noclean -eq 0 ]; then
-      clean=1
+    if [ ! -f openadk/dl/${libver}.tar.xz ]; then
+	usrc=$(mktemp -d /tmp/XXXX)
+	echo "Creating C library source tarball openadk/dl/${libver}.tar.xz"
+	cp -a $libcsource $usrc/$libver
+	mkdir -p $topdir/openadk/dl 2>/dev/null
+	rm $topdir/openadk/dl/${libver}.tar.xz 2>/dev/null
+	(cd $usrc && tar cJf $topdir/openadk/dl/${libver}.tar.xz ${libver} && rm -rf $usrc)
+	touch $topdir/openadk/dl/${libver}.tar.xz.nohash
+	# we need to clean system, when external source is used
+	if [ $noclean -eq 0 ]; then
+	    clean=1
+	fi
+    else
+      echo "Libc ${libver} tarball already exists, skipping creation"
     fi
   fi
   # binutils source used?
@@ -1708,18 +1712,22 @@ for lib in ${libc}; do
       echo "Not a directory."
       exit 1
     fi
-    usrc=$(mktemp -d /tmp/XXXX)
-    echo "Creating binutils source tarball openadk/dl/binutils-git.tar.xz"
-    (cd $binutilssource && ./src-release.sh binutils)
-    tar xf $binutilssource/binutils-*.tar -C $usrc
-    (cd $usrc && mv binutils-* binutils-git)
-    mkdir -p $topdir/openadk/dl 2>/dev/null
-    rm $topdir/openadk/dl/binutils-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/binutils-git.tar.xz binutils-git && rm -rf $usrc)
-    touch $topdir/openadk/dl/binutils-git.tar.xz.nohash
-    # we need to clean system, when external source is used
-    if [ $noclean -eq 0 ]; then
-      clean=1
+    if [ ! -f openadk/dl/binutils-git.tar.xz ]; then
+	usrc=$(mktemp -d /tmp/XXXX)
+	echo "Creating binutils source tarball openadk/dl/binutils-git.tar.xz"
+	(cd $binutilssource && ./src-release.sh binutils)
+	tar xf $binutilssource/binutils-*.tar -C $usrc
+	(cd $usrc && mv binutils-* binutils-git)
+	mkdir -p $topdir/openadk/dl 2>/dev/null
+	rm $topdir/openadk/dl/binutils-git.tar.xz 2>/dev/null
+	(cd $usrc && tar cJf $topdir/openadk/dl/binutils-git.tar.xz binutils-git && rm -rf $usrc)
+	touch $topdir/openadk/dl/binutils-git.tar.xz.nohash
+	# we need to clean system, when external source is used
+	if [ $noclean -eq 0 ]; then
+	    clean=1
+	fi
+    else
+      echo "Binutils tarball already exists, skipping creation"
     fi
   fi
   # gcc source used?
@@ -1728,16 +1736,20 @@ for lib in ${libc}; do
       echo "Not a directory."
       exit 1
     fi
-    usrc=$(mktemp -d /tmp/XXXX)
-    echo "Creating gcc source tarball openadk/dl/gcc-git.tar.xz"
-    cp -a $gccsource $usrc/gcc-git
-    mkdir -p $topdir/openadk/dl 2>/dev/null
-    rm $topdir/openadk/dl/gcc-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/gcc-git.tar.xz gcc-git && rm -rf $usrc)
-    touch $topdir/openadk/dl/gcc-git.tar.xz.nohash
-    # we need to clean system, when external source is used
-    if [ $noclean -eq 0 ]; then
-      clean=1
+    if [ ! -f openadk/dl/gcc-git.tar.xz ]; then
+	usrc=$(mktemp -d /tmp/XXXX)
+	echo "Creating gcc source tarball openadk/dl/gcc-git.tar.xz"
+	cp -a $gccsource $usrc/gcc-git
+	mkdir -p $topdir/openadk/dl 2>/dev/null
+	rm $topdir/openadk/dl/gcc-git.tar.xz 2>/dev/null
+	(cd $usrc && tar cJf $topdir/openadk/dl/gcc-git.tar.xz gcc-git && rm -rf $usrc)
+	touch $topdir/openadk/dl/gcc-git.tar.xz.nohash
+	# we need to clean system, when external source is used
+	if [ $noclean -eq 0 ]; then
+	    clean=1
+	fi
+    else
+      echo "GCC tarball already exists, skipping creation"
     fi
   fi
   # gdb source used?
@@ -1746,16 +1758,20 @@ for lib in ${libc}; do
       echo "Not a directory."
       exit 1
     fi
-    usrc=$(mktemp -d /tmp/XXXX)
-    echo "Creating gdb source tarball openadk/dl/gdb-git.tar.xz"
-    cp -a $gdbsource $usrc/gdb-git
-    mkdir -p $topdir/openadk/dl 2>/dev/null
-    rm $topdir/openadk/dl/gdb-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/gdb-git.tar.xz gdb-git && rm -rf $usrc)
-    touch $topdir/openadk/dl/gdb-git.tar.xz.nohash
-    # we need to clean system, when external source is used
-    if [ $noclean -eq 0 ]; then
-      clean=1
+    if [ ! -f openadk/dl/gdb-git.tar.xz ]; then
+	usrc=$(mktemp -d /tmp/XXXX)
+	echo "Creating gdb source tarball openadk/dl/gdb-git.tar.xz"
+	cp -a $gdbsource $usrc/gdb-git
+	mkdir -p $topdir/openadk/dl 2>/dev/null
+	rm $topdir/openadk/dl/gdb-git.tar.xz 2>/dev/null
+	(cd $usrc && tar cJf $topdir/openadk/dl/gdb-git.tar.xz gdb-git && rm -rf $usrc)
+	touch $topdir/openadk/dl/gdb-git.tar.xz.nohash
+	# we need to clean system, when external source is used
+	if [ $noclean -eq 0 ]; then
+	    clean=1
+	fi
+    else
+      echo "GDB tarball already exists, skipping creation"
     fi
   fi
   # Linux kernel source used?
@@ -1777,7 +1793,7 @@ for lib in ${libc}; do
         clean=1
       fi
     else
-      echo "Tarball already exist, skipping creation"
+      echo "Tarball already exists, skipping creation"
     fi
   fi
   # start with a clean dir

--- a/embedded-test.sh
+++ b/embedded-test.sh
@@ -1695,7 +1695,7 @@ for lib in ${libc}; do
     cp -a $libcsource $usrc/$libver
     mkdir -p $topdir/openadk/dl 2>/dev/null
     rm $topdir/openadk/dl/${libver}.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/${libver}.tar.xz ${libver} )
+    (cd $usrc && tar cJf $topdir/openadk/dl/${libver}.tar.xz ${libver} && rm -rf $usrc)
     touch $topdir/openadk/dl/${libver}.tar.xz.nohash
     # we need to clean system, when external source is used
     if [ $noclean -eq 0 ]; then
@@ -1715,7 +1715,7 @@ for lib in ${libc}; do
     (cd $usrc && mv binutils-* binutils-git)
     mkdir -p $topdir/openadk/dl 2>/dev/null
     rm $topdir/openadk/dl/binutils-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/binutils-git.tar.xz binutils-git)
+    (cd $usrc && tar cJf $topdir/openadk/dl/binutils-git.tar.xz binutils-git && rm -rf $usrc)
     touch $topdir/openadk/dl/binutils-git.tar.xz.nohash
     # we need to clean system, when external source is used
     if [ $noclean -eq 0 ]; then
@@ -1733,7 +1733,7 @@ for lib in ${libc}; do
     cp -a $gccsource $usrc/gcc-git
     mkdir -p $topdir/openadk/dl 2>/dev/null
     rm $topdir/openadk/dl/gcc-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/gcc-git.tar.xz gcc-git)
+    (cd $usrc && tar cJf $topdir/openadk/dl/gcc-git.tar.xz gcc-git && rm -rf $usrc)
     touch $topdir/openadk/dl/gcc-git.tar.xz.nohash
     # we need to clean system, when external source is used
     if [ $noclean -eq 0 ]; then
@@ -1751,7 +1751,7 @@ for lib in ${libc}; do
     cp -a $gdbsource $usrc/gdb-git
     mkdir -p $topdir/openadk/dl 2>/dev/null
     rm $topdir/openadk/dl/gdb-git.tar.xz 2>/dev/null
-    (cd $usrc && tar cJf $topdir/openadk/dl/gdb-git.tar.xz gdb-git)
+    (cd $usrc && tar cJf $topdir/openadk/dl/gdb-git.tar.xz gdb-git && rm -rf $usrc)
     touch $topdir/openadk/dl/gdb-git.tar.xz.nohash
     # we need to clean system, when external source is used
     if [ $noclean -eq 0 ]; then
@@ -1770,7 +1770,7 @@ for lib in ${libc}; do
       cp -a $kernelsource $usrc/linux-git
       mkdir -p $topdir/openadk/dl 2>/dev/null
       rm $topdir/openadk/dl/linux-git.tar.xz 2>/dev/null
-      (cd $usrc && tar cJf $topdir/openadk/dl/linux-git.tar.xz linux-git)
+      (cd $usrc && tar cJf $topdir/openadk/dl/linux-git.tar.xz linux-git && rm -rf $usrc)
       touch $topdir/openadk/dl/linux-git.tar.xz.nohash
       # we need to clean system, when external source is used
       if [ $noclean -eq 0 ]; then


### PR DESCRIPTION
These small patches are easy cleanups:
- avoid filling up /tmp with temporary source trees
- avoid re-creating tarballs if already present
